### PR TITLE
Implement `tuples(output(r))` - a TuplesIterator, with rich REPL display

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,10 @@ uuid = "b77b3abe-013f-4f9b-9096-7c0754454eb7"
 authors = ["Nathan Daly <nhdaly@gmail.com> and contributors"]
 version = "0.1.0"
 
+[deps]
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+RAI = "9c30249a-7e08-11ec-0e99-a323e937e79f"
+
 [compat]
 julia = "1"
 

--- a/src/RAISDKResultsWrapper.jl
+++ b/src/RAISDKResultsWrapper.jl
@@ -1,5 +1,118 @@
 module RAISDKResultsWrapper
 
-# Write your package code here.
+import RAI
+import JSON3
+
+
+export output, tuples
+
+function output(transaction_result)
+    return ResultsCursor(transaction_result.output)
+end
+
+struct ResultsCursor  # TODO: Name?
+    json_outputs::JSON3.Array
+end
+
+#function Base.show(io::IO, ::MIME"text/plain", cursor::ResultsCursor)
+#    #len =
+#    print(io, "$ResultsCursor with ")
+#end
+
+function tuples(cursor::ResultsCursor)
+    len = sum(_num_tuples(r) for r in relations(cursor))
+    tuples = (
+        row_getter(i)
+        for r in sort(relations(cursor), by=r->r.relpath)
+        for row_getter in (RAI._make_getrow(r.relpath, r.columns),)
+        for i in 1:_num_tuples(r)
+    )
+    return TuplesIterator(len, tuples)
+end
+
+function _constants_positions(relpath)
+    return ((i,v) for (i,v) in enumerate(relpath) if startswith(v,':'))
+end
+
+struct TuplesIterator{G}
+    length::Int
+    generator::G
+end
+
+# iteration interface
+Base.iterate(t::TuplesIterator, args...) = iterate(t.generator, args...)
+Base.length(t::TuplesIterator) = t.length
+Base.eltype(::Type{<:TuplesIterator}) = Tuple
+
+
+function Base.show(io::IO, ::MIME"text/plain", tuples::TuplesIterator)
+    print(io, "$TuplesIterator with $(tuples.length) tuples:")
+    # isempty(iter) && get(io, :compact, false) && return show(io, iter)
+    # summary(io, iter)
+    # isempty(iter) && return
+    # print(io, ". ", isa(iter,KeySet) ? "Keys" : "Values", ":")
+    _show_list(io, tuples)
+end
+
+function _show_list(io::IO, iter)
+    limit = get(io, :limit, false)::Bool
+    if limit
+        sz = displaysize(io)
+        rows, cols = sz[1] - 3, sz[2]
+        rows < 2 && (print(io, " …"); return)
+        cols < 4 && (cols = 4)
+        cols -= 2 # For prefix "  "
+        rows -= 1 # For summary
+    else
+        rows = cols = typemax(Int)
+    end
+
+    for (i, v) in enumerate(iter)
+        print(io, "\n  ")
+        i == rows < length(iter) && (print(io, "⋮"); break)
+
+        if limit
+            str = sprint(show, v, context=io, sizehint=0)
+            str = Base._truncate_at_width_or_chars(str, cols, "\r\n")
+            print(io, str)
+        else
+            show(io, v)
+        end
+    end
+end
+
+
+
+function relations(cursor::ResultsCursor)
+    return PhysicalRelation[
+        PhysicalRelation(_relpath_from_rel_key(relation.rel_key), relation.columns)
+        for relation in cursor.json_outputs
+    ]
+end
+function _relpath_str(rel_key::JSON3.Object)
+    name_and_keys = reduce(joinpath, rel_key.keys, init=":$(rel_key.name)")
+    name_keys_values = reduce(joinpath, rel_key.values, init=name_and_keys)
+    return name_keys_values
+end
+function _relpath_from_rel_key(rel_key::JSON3.Object)
+    return String[":$(rel_key.name)", rel_key.keys..., rel_key.values...]
+end
+
+struct PhysicalRelation
+    relpath::Vector{String}
+    columns::JSON3.Array
+end
+
+_num_tuples(r::PhysicalRelation) = max(length(r.columns[1]), 1)
+
+struct RelationTuples
+    columns::JSON3.Array
+end
+
+function Base.show(io::IO, tuples::RelationTuples)
+    print(io, "$RelationTuples([])")
+end
+
+
 
 end

--- a/src/RAISDKResultsWrapper.jl
+++ b/src/RAISDKResultsWrapper.jl
@@ -5,6 +5,7 @@ import JSON3
 
 
 export output, tuples
+export ResultsCursor, TuplesIterator, PhysicalRelation
 
 function output(transaction_result)
     return ResultsCursor(transaction_result.output)
@@ -52,6 +53,8 @@ function Base.show(io::IO, tuples::TuplesIterator)
 end
 
 function Base.show(io::IO, ::MIME"text/plain", tuples::TuplesIterator)
+    isempty(tuples) && return show(io, tuples)
+
     print(io, "$TuplesIterator with $(tuples.length) tuples:")
     # isempty(iter) && get(io, :compact, false) && return show(io, iter)
     # summary(io, iter)

--- a/src/RAISDKResultsWrapper.jl
+++ b/src/RAISDKResultsWrapper.jl
@@ -38,12 +38,18 @@ struct TuplesIterator{G}
     length::Int
     generator::G
 end
+TuplesIterator(itr) = TuplesIterator(length(itr), itr)
 
 # iteration interface
 Base.iterate(t::TuplesIterator, args...) = iterate(t.generator, args...)
 Base.length(t::TuplesIterator) = t.length
 Base.eltype(::Type{<:TuplesIterator}) = Tuple
 
+function Base.show(io::IO, tuples::TuplesIterator)
+    Base.print(io, "$TuplesIterator(")
+    Base.show(io, collect(Tuple, tuples.generator))
+    Base.print(io, ")")
+end
 
 function Base.show(io::IO, ::MIME"text/plain", tuples::TuplesIterator)
     print(io, "$TuplesIterator with $(tuples.length) tuples:")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,21 @@
 using RAISDKResultsWrapper
 using Test
 
+import RAI
+
+ctx = RAI.Context(RAI.load_config()); config = (ctx, "nhd-test-1", "nhd-s");
+config = (ctx, "nhd-test-1", "nhd-s");
+r = RAI.exec(config..., """:a, (1;2;(3,"hi")); :b,"hi",:c,(range[2,15,1]); :x,true; :y,100 """)
+
 @testset "RAISDKResultsWrapper.jl" begin
-    # Write your tests here.
+    cursor = output(r)
+
+    tups = tuples(cursor)
+    @test length(tups) == 19
+    @test eltype(tups) == Tuple
+    @test collect(tups) isa Vector{Tuple}
+    @test length(collect(tups)) == 19
+
+    show(tups)
+    display(tups)
 end


### PR DESCRIPTION
Commits:

* [Implement tuples(output(r)) - a TuplesIterator](https://github.com/NHDaly/RAISDKResultsWrapper.jl/commit/4c840ac76e6ee2200c3f28bb4b52ab2e16bd8f30)

e.g.
```julia
julia> tuples(output(r))
TuplesIterator with 19 tuples:
  (:output, :a, 1)
  (:output, :a, 2)
  (:output, :a, 3, "hi")
  (:output, :b, "hi", :c, 2)
  (:output, :b, "hi", :c, 3)
  (:output, :b, "hi", :c, 4)
  (:output, :b, "hi", :c, 5)
  (:output, :b, "hi", :c, 6)
  (:output, :b, "hi", :c, 7)
  ⋮

julia> collect(tuples(output(r)))
19-element Vector{Tuple}:
 (:output, :a, 1)
 (:output, :a, 2)
 (:output, :a, 3, "hi")
 (:output, :b, "hi", :c, 2)
 (:output, :b, "hi", :c, 3)
 ⋮
 (:output, :b, "hi", :c, 14)
 (:output, :b, "hi", :c, 15)
 (:output, :x)
 (:output, :y, 100)

julia>
```

* [Add a 2-arg show method that is reproducible at the REPL:](https://github.com/NHDaly/RAISDKResultsWrapper.jl/commit/16f76272ac9abec7e83e63260d0c5a2e82d59d3e)
```julia
julia> show(W.tuples(W.output(r)))
RAISDKResultsWrapper.TuplesIterator(Tuple[(:output, :a, 1), (:output, :a, 2), (:output, :a, 3, "hi"), (:output, :b, "hi", :c, 2), (:output, :b, "hi", :c, 3), (:output, :b, "hi", :c, 4), (:output, :b, "hi", :c, 5), (:output, :b, "hi", :c, 6), (:output, :b, "hi", :c, 7), (:output, :b, "hi", :c, 8), (:output, :b, "hi", :c, 9), (:output, :b, "hi", :c, 10), (:output, :b, "hi", :c, 11), (:output, :b, "hi", :c, 12), (:output, :b, "hi", :c, 13), (:output, :b, "hi", :c, 14), (:output, :b, "hi", :c, 15), (:output, :x), (:output, :y, 100)])
julia>

julia> RAISDKResultsWrapper.TuplesIterator(Tuple[(:output, :a, 1), (:output, :a, 2), (:output, :a, 3, "hi"), (:output, :b, "hi", :c, 2), (:output, :b, "hi", :c, 3), (:output, :b, "hi", :c, 4), (:output, :b, "hi", :c, 5), (:output, :b, "hi", :c, 6), (:output, :b, "hi", :c, 7), (:output, :b, "hi", :c, 8), (:output, :b, "hi", :c, 9), (:output, :b, "hi", :c, 10), (:output, :b, "hi", :c, 11), (:output, :b, "hi", :c, 12), (:output, :b, "hi", :c, 13), (:output, :b, "hi", :c, 14), (:output, :b, "hi", :c, 15), (:output, :x), (:output, :y, 100)])
RAISDKResultsWrapper.TuplesIterator with 19 tuples:
  (:output, :a, 1)
  (:output, :a, 2)
  (:output, :a, 3, "hi")
  (:output, :b, "hi", :c, 2)
  (:output, :b, "hi", :c, 3)
  (:output, :b, "hi", :c, 4)
  (:output, :b, "hi", :c, 5)
  (:output, :b, "hi", :c, 6)
  (:output, :b, "hi", :c, 7)
  (:output, :b, "hi", :c, 8)
  (:output, :b, "hi", :c, 9)
  (:output, :b, "hi", :c, 10)
  (:output, :b, "hi", :c, 11)
  (:output, :b, "hi", :c, 12)
  (:output, :b, "hi", :c, 13)
  (:output, :b, "hi", :c, 14)
  (:output, :b, "hi", :c, 15)
  (:output, :x)
  (:output, :y, 100)

```

* [3-arg show for empty tuples](https://github.com/NHDaly/RAISDKResultsWrapper.jl/commit/573d9dc64934527009b74cd7af8876e0ff0112fd) 

```julia
julia> TuplesIterator([])
TuplesIterator(Tuple[])
```
