### PR TITLE
For now, display the results cursor as Tuples list.. Long-term goal is to display it as a Trie.

### DIFF
--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -6,10 +6,13 @@ struct ResultsCursor  # TODO: Name?
     json_outputs::JSON3.Array
 end
 
-#function Base.show(io::IO, ::MIME"text/plain", cursor::ResultsCursor)
-#    #len =
-#    print(io, "$ResultsCursor with ")
-#end
+# TODO: for now, we just show tuples(), but the goal is to show a Trie here!
+function Base.show(io::IO, ::MIME"text/plain", cursor::ResultsCursor)
+    tups = tuples(cursor)
+    rels = relations(cursor)
+    print(io, "$ResultsCursor with $(length(tups)) tuples in $(length(rels)) physical relations:")
+    _show_list(io, tups)
+end
 
 
 function tuples(cursor::ResultsCursor)


### PR DESCRIPTION

```julia
julia> cursor = output(r)
ResultsCursor with 19 tuples in 5 physical relations:
  (:output, :a, 1)
  (:output, :a, 2)
  (:output, :a, 3, "hi")
  (:output, :b, "hi", :c, 2)
  (:output, :b, "hi", :c, 3)
  (:output, :b, "hi", :c, 4)
  (:output, :b, "hi", :c, 5)
  (:output, :b, "hi", :c, 6)
  (:output, :b, "hi", :c, 7)
  (:output, :b, "hi", :c, 8)
  (:output, :b, "hi", :c, 9)
  (:output, :b, "hi", :c, 10)
  ⋮
```