### PR TITLE
Verrrrrry rough draft of trie walking for results :) 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Nathan Daly <nhdaly@gmail.com> and contributors"]
 version = "0.1.0"
 
 [deps]
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 RAI = "9c30249a-7e08-11ec-0e99-a323e937e79f"
 

--- a/src/RAISDKResultsWrapper.jl
+++ b/src/RAISDKResultsWrapper.jl
@@ -2,7 +2,7 @@ module RAISDKResultsWrapper
 
 import RAI
 import JSON3
-
+using DataStructures: OrderedSet
 
 export output, tuples, relations
 export ResultsCursor, TuplesIterator, PhysicalRelation

--- a/src/RAISDKResultsWrapper.jl
+++ b/src/RAISDKResultsWrapper.jl
@@ -9,6 +9,7 @@ export ResultsCursor, TuplesIterator, PhysicalRelation
 
 include("tuples.jl")
 include("physical-relations.jl")
+include("trie-iterator.jl")
 include("cursor.jl")
 
 end

--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -48,7 +48,7 @@ end
 function tuples(cursor::ResultsCursor)
     len = sum((_num_tuples(r) for r in relations(cursor)), init=0)
     tuples = (
-        row_getter(i)
+        row_getter(i)[(length(cursor.iterator.prefix)+1):end]
         for r in sort(relations(cursor), by=r->r.relpath)
         for row_getter in (RAI._make_getrow(r.relpath, r.columns),)
         for i in 1:_num_tuples(r)

--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -9,11 +9,13 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", cursor::ResultsCursor)
     num_rels = length(cursor.iterator.relations)
-    print(io, "$ResultsCursor with <TODO> tuples in $(num_rels) physical relations:")
+    tups = tuples(cursor)
+    print(io, "$ResultsCursor with $(length(tups)) tuples in $(num_rels) physical relations:")
     _show_trie(io, cursor)
 end
 
 
+Base.keytype(_::ResultsCursor) = Any
 Base.keys(cursor::ResultsCursor) = keys(cursor.iterator)
 Base.getindex(cursor::ResultsCursor, element) = ResultsCursor(cursor.iterator[element])
 function Base.getindex(cursor::ResultsCursor, elements...)
@@ -35,10 +37,14 @@ function __show_trie(io, cursor::ResultsCursor; indent=0, num_lines = 10)
             print("\n" * " "^indent, "⋮")
             return
         end
-        print("\n" * " "^indent, repr(key), " => ")
-        __show_trie(io, cursor[key];
-            indent = indent + length(key)+1,
-            num_lines = num_lines)
+        print("\n" * " "^indent, repr(key))
+        subcursor = cursor[key]
+        #if !isempty(tuples(subcursor))
+            print(io, " => ")
+            __show_trie(io, subcursor;
+                indent = indent + length(key)+1,
+                num_lines = num_lines)
+        #end
     end
 end
 

--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -1,9 +1,11 @@
 function output(transaction_result)
-    return ResultsCursor(transaction_result.output)
+    json = transaction_result.output
+    return ResultsCursor(TrieWalker(relations(json)), json)
 end
 
 struct ResultsCursor  # TODO: Name?
-    json_outputs::JSON3.Array
+    iterator::TrieWalker
+    _json_outputs::JSON3.Array
 end
 
 # TODO: for now, we just show tuples(), but the goal is to show a Trie here!
@@ -28,9 +30,13 @@ end
 
 
 function relations(cursor::ResultsCursor)
+    return relations(cursor._json_outputs)
+end
+
+function relations(outputs::JSON3.Array)
     return PhysicalRelation[
         PhysicalRelation(_relpath_from_rel_key(relation.rel_key), relation.columns)
-        for relation in cursor.json_outputs
+        for relation in outputs
     ]
 end
 function _relpath_str(rel_key::JSON3.Object)

--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -8,13 +8,43 @@ struct ResultsCursor  # TODO: Name?
     _json_outputs::JSON3.Array
 end
 
-# TODO: for now, we just show tuples(), but the goal is to show a Trie here!
 function Base.show(io::IO, ::MIME"text/plain", cursor::ResultsCursor)
-    tups = tuples(cursor)
-    rels = relations(cursor)
-    print(io, "$ResultsCursor with $(length(tups)) tuples in $(length(rels)) physical relations:")
-    _show_list(io, tups)
+    num_rels = length(cursor.iterator.relations)
+    print(io, "$ResultsCursor with <TODO> tuples in $(num_rels) physical relations:")
+    _show_trie(io, cursor)
 end
+
+
+Base.keys(cursor::ResultsCursor) = keys(cursor.iterator)
+Base.getindex(cursor::ResultsCursor, element) =
+    ResultsCursor(cursor.iterator[element], cursor._json_outputs)
+function Base.getindex(cursor::ResultsCursor, elements...)
+    for element in elements
+        cursor = getindex(cursor, element)
+    end
+    return cursor
+end
+
+
+
+function _show_trie(io, cursor::ResultsCursor)
+    __show_trie(io, cursor)
+end
+function __show_trie(io, cursor::ResultsCursor; indent=0, num_lines = 10)
+    for key in keys(cursor)
+        num_lines -= 1
+        if num_lines < 0
+            print("\n" * " "^indent, "⋮")
+            return
+        end
+        print("\n" * " "^indent, repr(key), " => ")
+        __show_trie(io, cursor[key];
+            indent = indent + length(key)+1,
+            num_lines = num_lines)
+    end
+end
+
+
 
 
 function tuples(cursor::ResultsCursor)

--- a/src/cursor.jl
+++ b/src/cursor.jl
@@ -1,11 +1,10 @@
 function output(transaction_result)
     json = transaction_result.output
-    return ResultsCursor(TrieWalker(relations(json)), json)
+    return ResultsCursor(TrieWalker(relations(json)))
 end
 
 struct ResultsCursor  # TODO: Name?
     iterator::TrieWalker
-    _json_outputs::JSON3.Array
 end
 
 function Base.show(io::IO, ::MIME"text/plain", cursor::ResultsCursor)
@@ -16,8 +15,7 @@ end
 
 
 Base.keys(cursor::ResultsCursor) = keys(cursor.iterator)
-Base.getindex(cursor::ResultsCursor, element) =
-    ResultsCursor(cursor.iterator[element], cursor._json_outputs)
+Base.getindex(cursor::ResultsCursor, element) = ResultsCursor(cursor.iterator[element])
 function Base.getindex(cursor::ResultsCursor, elements...)
     for element in elements
         cursor = getindex(cursor, element)
@@ -60,7 +58,10 @@ end
 
 
 function relations(cursor::ResultsCursor)
-    return relations(cursor._json_outputs)
+    return PhysicalRelation[
+        r_iter.relation
+        for r_iter in cursor.iterator.relations
+    ]
 end
 
 function relations(outputs::JSON3.Array)

--- a/src/physical-relations.jl
+++ b/src/physical-relations.jl
@@ -27,6 +27,17 @@ function tuples(r::PhysicalRelation)
     )
     return TuplesIterator(len, tuples)
 end
+function tuples(rs::Vector{PhysicalRelation})
+    len = sum((_num_tuples(r) for r in rs), init=0)
+    tuples = (
+        row_getter(i)
+        for r in sort(rs, by=r->r.relpath)
+        for row_getter in (RAI._make_getrow(r.relpath, r.columns),)
+        for i in 1:_num_tuples(r)
+    )
+    return TuplesIterator(len, tuples)
+end
+
 
 function Base.show(io::IO, r::PhysicalRelation)
     print(io, "$PhysicalRelation($(r.relpath), ")

--- a/src/trie-iterator.jl
+++ b/src/trie-iterator.jl
@@ -17,6 +17,9 @@ function _unspecialized_columns(relation::PhysicalRelation)
     ]
 end
 
+# TODO: haha oh shit, i've got to change this back to iterating over tuples, so that we can
+# handle the end of the prefix. 🙄
+# We need to do the binary search on the tuples() object directly
 struct PhysicalRelationIterator
     relpath::Vector{String}
     maybe_columns::Vector{ColumnOrSpecialized}
@@ -50,7 +53,7 @@ function Base.keys(t::TrieWalker)
     e = length(t.prefix) + 1
 
     keyset = sizehint!(OrderedSet{Any}(), length(t.relations))
-    for iter in t.relations
+    for iter in sort(t.relations, by=r->r.relpath)
         if e <= length(iter.maybe_columns)
             maybe_col = iter.maybe_columns[e]
             if maybe_col.type == SPECIALIZED

--- a/src/trie-iterator.jl
+++ b/src/trie-iterator.jl
@@ -20,15 +20,16 @@ end
 struct PhysicalRelationIterator
     relpath::Vector{String}
     maybe_columns::Vector{ColumnOrSpecialized}
+    relation::PhysicalRelation
 
     row_idx::Int # Current row offset into the relation
 end
 
 function PhysicalRelationIterator(r::PhysicalRelation)
-    return PhysicalRelationIterator(r.relpath, _unspecialized_columns(r), 1)
+    return PhysicalRelationIterator(r.relpath, _unspecialized_columns(r), r, 1)
 end
 function seek_to(iter::PhysicalRelationIterator, i::Int)
-    return PhysicalRelationIterator(iter.relpath, iter.maybe_columns, i)
+    return PhysicalRelationIterator(iter.relpath, iter.maybe_columns, iter.relation, i)
 end
 
 struct TrieWalker

--- a/src/trie-iterator.jl
+++ b/src/trie-iterator.jl
@@ -1,0 +1,96 @@
+
+@enum ColumnType SPECIALIZED VALUES
+struct ColumnOrSpecialized
+    type::ColumnType
+    val::Union{Any,Vector}
+end
+function _unspecialized_columns(relation::PhysicalRelation)
+    col = 0
+    ColumnOrSpecialized[
+        if startswith(v, ':')
+            ColumnOrSpecialized(SPECIALIZED, v)
+        else
+            col += 1
+            ColumnOrSpecialized(VALUES, relation.columns[col])
+        end
+        for v in relation.relpath
+    ]
+end
+
+struct PhysicalRelationIterator
+    relpath::Vector{String}
+    maybe_columns::Vector{ColumnOrSpecialized}
+
+    row_idx::Int # Current row offset into the relation
+end
+
+function PhysicalRelationIterator(r::PhysicalRelation)
+    return PhysicalRelationIterator(r.relpath, _unspecialized_columns(r), 1)
+end
+function seek_to(iter::PhysicalRelationIterator, i::Int)
+    return PhysicalRelationIterator(iter.relpath, iter.maybe_columns, i)
+end
+
+struct TrieWalker
+    relations::Vector{PhysicalRelationIterator}
+    # relations::Vector{PhysicalRelation}
+    # element_getters::Vector{Any}
+    # slots::Vector{Vector{Int}}
+    # column_getters::Vector{Vector{Int}}
+    # TODO: Should this be a dynamically sized collection instead, like a vector? I think probably.
+    prefix::Tuple
+end
+
+function TrieWalker(relations::Vector{PhysicalRelation})
+    return TrieWalker([PhysicalRelationIterator(r) for r in relations], ())
+end
+
+function Base.getindex(t::TrieWalker, v)
+    e = length(t.prefix) + 1
+
+    new_iters = sizehint!(empty(t.relations), length(t.relations))
+    for iter in t.relations
+        new_idx = _seek_match(iter, iter.row_idx, e, v)
+        if new_idx !== NotFound()
+            iter = seek_to(iter, new_idx)
+            push!(new_iters, iter)
+        else
+            # drop the iterator
+        end
+    end
+
+    TrieWalker(new_iters, (t.prefix..., v))
+end
+
+struct NotFound end
+
+function _seek_match(iter, start_idx::Int, elt_idx::Int, v)
+    if elt_idx > length(iter.maybe_columns)
+        return NotFound()
+    end
+    maybe_col = iter.maybe_columns[elt_idx]
+    if maybe_col.type == SPECIALIZED
+        return maybe_col.val == v ? start_idx : NotFound()
+    end
+    # Otherwise, it's a normal column
+    col = maybe_col.val::AbstractVector
+
+    # Do a binary search from start_idx to end until you find `v` in column elt_idx
+    new_idx = binary_search_from(col, start_idx, v)
+
+    if new_idx <= length(col) && col[new_idx] == v
+        return new_idx
+    else
+        return NotFound()
+    end
+end
+
+binary_search_from(col, start, v) = searchsortedfirst(@view(col[start:end]), v) + start-1
+
+function _make_element_getter(relation::PhysicalRelation, elt)
+    # TODO: don't need to do all of this.
+    row_getter = RAI._make_getrow(r.relpath, r.columns)
+
+    return idx->row_getter[idx][elt]
+end
+

--- a/src/trie-iterator.jl
+++ b/src/trie-iterator.jl
@@ -45,6 +45,27 @@ function TrieWalker(relations::Vector{PhysicalRelation})
     return TrieWalker([PhysicalRelationIterator(r) for r in relations], ())
 end
 
+function Base.keys(t::TrieWalker)
+    e = length(t.prefix) + 1
+
+    keyset = sizehint!(OrderedSet{Any}(), length(t.relations))
+    for iter in t.relations
+        if e <= length(iter.maybe_columns)
+            maybe_col = iter.maybe_columns[e]
+            if maybe_col.type == SPECIALIZED
+                push!(keyset, maybe_col.val)
+            else
+                col = maybe_col.val::AbstractVector
+                sizehint!(keyset, length(keyset) + length(col))
+                for v in col
+                    push!(keyset, v)
+                end
+            end
+        end
+    end
+    return keyset
+end
+
 function Base.getindex(t::TrieWalker, v)
     e = length(t.prefix) + 1
 


### PR DESCRIPTION
```julia
julia> cursor = output(r)
ResultsCursor with <TODO> tuples in 5 physical relations:
":output" =>
        ":x" =>
        ":y" =>
           100 =>
        ":a" =>
           1 =>
           2 =>
           3 =>
             "hi" =>
        ":b" =>
           "hi" =>
              ":c" =>
                 2 =>
                 3 =>
                 4 =>
                 ⋮

julia> cursor[":output"]
ResultsCursor with <TODO> tuples in 5 physical relations:
":x" =>
":y" =>
   100 =>
":a" =>
   1 =>
   2 =>
   3 =>
     "hi" =>
":b" =>
   "hi" =>
      ":c" =>
         2 =>
         3 =>
         4 =>
         5 =>
         ⋮

julia> cursor[":output"][":a"]
ResultsCursor with <TODO> tuples in 2 physical relations:
1 =>
2 =>
3 =>
  "hi" =>

julia> cursor[":output"][":a"][2]
ResultsCursor with <TODO> tuples in 1 physical relations:

julia> cursor[":output"][":a"][4]
ResultsCursor with <TODO> tuples in 0 physical relations:

julia> cursor[":output"][":a"][3]
ResultsCursor with <TODO> tuples in 1 physical relations:
"hi" =>
```

Obviously very rough draft, missing the tuples counts, and looks
terrible, but more or less captures the idea! :)

For comparison:
```julia
julia> collect(tuples(cursor))
19-element Vector{Tuple}:
 (:output, :a, 1)
 (:output, :a, 2)
 (:output, :a, 3, "hi")
 (:output, :b, "hi", :c, 2)
 (:output, :b, "hi", :c, 3)
 (:output, :b, "hi", :c, 4)
 (:output, :b, "hi", :c, 5)
 (:output, :b, "hi", :c, 6)
 (:output, :b, "hi", :c, 7)
 (:output, :b, "hi", :c, 8)
 (:output, :b, "hi", :c, 9)
 (:output, :b, "hi", :c, 10)
 (:output, :b, "hi", :c, 11)
 (:output, :b, "hi", :c, 12)
 (:output, :b, "hi", :c, 13)
 (:output, :b, "hi", :c, 14)
 (:output, :b, "hi", :c, 15)
 (:output, :x)
 (:output, :y, 100)
```

* [Filter relations(::Cursor) to only the matching relations](https://github.com/NHDaly/RAISDKResultsWrapper.jl/commit/51c69711ed22cc1217c33adaa7dbbce412a700b6) 

```julia
julia> relations(cursor[":output"][":a"])
2-element Vector{PhysicalRelation}:
 PhysicalRelation([":output", ":a", "Int64"], TuplesIterator(Tuple[(:output, :a, 1), (:output, :a, 2)]))
 PhysicalRelation([":output", ":a", "Int64", "String"], TuplesIterator(Tuple[(:output, :a, 3, "hi")]))

julia> tuples(cursor[":output"][":a"])
TuplesIterator with 3 tuples:
  (:output, :a, 1)
  (:output, :a, 2)
  (:output, :a, 3, "hi")
```

* [filter tuples(::Cursor) to only the tuple suffixes](https://github.com/NHDaly/RAISDKResultsWrapper.jl/commit/2ad0dda3ef873b34e11bd7b65658392f0a64f221) 

```julia
julia> tuples(cursor[":output"][":y"])
TuplesIterator with 1 tuples:
  (100,)

julia> tuples(cursor[":output"][":x"])
TuplesIterator with 1 tuples:
  ()

julia> tuples(cursor[":output"][":a"])
TuplesIterator with 3 tuples:
  (1,)
  (2,)
  (3, "hi")

julia> tuples(cursor[":output"][":a"][3])
TuplesIterator with 1 tuples:
  ("hi",)
```

Add tuples(::Vector{PhysicalRelation})
```julia
julia> cursor[":output"][":a"]
ResultsCursor with <TODO> tuples in 2 physical relations:
1 =>
2 =>
3 =>
  "hi" =>

julia> tuples(cursor[":output"][":a"])
TuplesIterator with 3 tuples:
  (1,)
  (2,)
  (3, "hi")

julia> relations(cursor[":output"][":a"])
2-element Vector{PhysicalRelation}:
 PhysicalRelation([":output", ":a", "Int64"], TuplesIterator(Tuple[(:output, :a, 1), (:output, :a, 2)]))
 PhysicalRelation([":output", ":a", "Int64", "String"], TuplesIterator(Tuple[(:output, :a, 3, "hi")]))

julia> tuples(relations(cursor[":output"][":a"]))
TuplesIterator with 3 tuples:
  (:output, :a, 1)
  (:output, :a, 2)
  (:output, :a, 3, "hi")

```